### PR TITLE
chore: use capnproto for persistent data storage

### DIFF
--- a/collector/src/ffi.rs
+++ b/collector/src/ffi.rs
@@ -37,7 +37,7 @@ pub struct LoopStats {
 
 #[allow(dead_code)]
 pub struct LoopHandle {
-    id: u64,
+    id: u128,
     timestamp: u64,
     info: SafeLoopInfo,
 }

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -36,7 +36,7 @@ pub fn get_next_id() -> u128 {
         last as u128
     });
 
-    ((std::process::id() as u128) << 96) | ((unsafe { libc::gettid() as u128}) << 64) | counter
+    ((std::process::id() as u128) << 96) | ((unsafe { libc::gettid() as u128 }) << 64) | counter
 }
 
 pub fn profiling_enabled() -> bool {

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -1,6 +1,5 @@
-use atomic_counter::{AtomicCounter, ConsistentCounter};
 use lazy_static::lazy_static;
-use std::sync::Mutex;
+use std::{cell::RefCell, sync::Mutex};
 
 use mperf_data::Event;
 use shmem::proc_channel::Sender;
@@ -14,18 +13,13 @@ lazy_static! {
 
         Mutex::new(Sender::attach(&name, 8192).expect("failed to open shared memory"))
     };
-    static ref ID_COUNTER: ConsistentCounter = {
-        let start = std::env::var("MPERF_COLLECTOR_IDS_START")
-            .expect("MPERF_COLLECTOR_IDS_START must be set by the caller");
-        ConsistentCounter::new(
-            start
-                .parse::<usize>()
-                .expect("MPERF_COLLECTOR_IDS_START must be an unsigned integer"),
-        )
-    };
     static ref PROFILING_ENABLED: bool = std::env::var("MPERF_COLLECTOR_ENABLED").is_ok();
     static ref ROOFLINE_INSTR_ENABLED: bool =
         std::env::var("MPERF_COLLECTOR_ROOFLINE_INSTRUMENTED").is_ok();
+}
+
+thread_local! {
+    static LAST_ID: RefCell<u64> = const { RefCell::new(0) };
 }
 
 pub fn send_event(evt: Event) -> Result<(), Box<dyn std::error::Error>> {
@@ -35,8 +29,14 @@ pub fn send_event(evt: Event) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-pub fn get_next_id() -> u64 {
-    ID_COUNTER.inc() as u64
+pub fn get_next_id() -> u128 {
+    let counter = LAST_ID.with_borrow_mut(|cnt| {
+        let last = *cnt;
+        *cnt += 1;
+        last as u128
+    });
+
+    ((std::process::id() as u128) << 96) | ((unsafe { libc::gettid() as u128}) << 64) | counter
 }
 
 pub fn profiling_enabled() -> bool {

--- a/mperf-data/Cargo.toml
+++ b/mperf-data/Cargo.toml
@@ -11,9 +11,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4.5.23", features = ["derive"] }
 capnp = "0.20.3"
-flatbuffers = "24.12.23"
 
 [build-dependencies]
 capnpc = "0.20.1"
-flatc = "0.2.2"
-flatc-rust = "0.2.0"

--- a/mperf-data/build.rs
+++ b/mperf-data/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    ::capnpc::CompilerCommand::new()
+        .file("schema/event.capnp")
+        .run()
+        .expect("compiling schema");
+}

--- a/mperf-data/schema/event.capnp
+++ b/mperf-data/schema/event.capnp
@@ -2,11 +2,50 @@
 
 struct EventId {
   p1 @0 : UInt64;
-  p2 @0 : UInt64;
+  p2 @1 : UInt64;
 }
 
 enum EventType {
-  PMU,
+  pmuCycles @0;
+  pmuInstructions @1;
+  pmuLLCReferences @2;
+  pmuLLCMisses @3;
+  pmuBranchInstructions @4;
+  pmuBranchMisses @5;
+  pmuStalledCyclesFrontend @6;
+  pmuStalledCyclesBackend @7;
+  pmuCustom @8;
+  osCpuClock @9;
+  osCpuMigrations @10;
+  osPageFaults @11;
+  osContextSwitches @12;
+  osTotalTime @13;
+  osUserTime @14;
+  osSystemTime @15;
+  rooflineBytesLoad @16;
+  rooflineBytesStore @17;
+  rooflineScalarIntOps @18;
+  rooflineScalarFloatOps @19;
+  rooflineScalarDoubleOps @20;
+  rooflineVectorIntOps @21;
+  rooflineVectorFloatOps @22;
+  rooflineVectorDoubleOps @23;
+  rooflineLoopStart @24;
+  rooflineLoopEnd @25;
+}
+
+struct Location {
+  functionName @0 : EventId;
+  filename @1 : EventId;
+  line @2 : UInt32;
+}
+
+struct Metadata {
+  key @0 : EventId;
+  union {
+    string @1 : EventId;
+    integer @2 : UInt64;
+  }
 }
 
 struct Event {
@@ -20,4 +59,6 @@ struct Event {
   timeRunning @7 : UInt64;
   timestamp @8 : UInt64;
   value @9 : UInt64;
+  callstack @10 : List(Location);
+  metadata @11 : List(Metadata);
 }

--- a/mperf-data/schema/event.capnp
+++ b/mperf-data/schema/event.capnp
@@ -1,0 +1,23 @@
+@0x93e2c78a503bc43a;
+
+struct EventId {
+  p1 @0 : UInt64;
+  p2 @0 : UInt64;
+}
+
+enum EventType {
+  PMU,
+}
+
+struct Event {
+  uniqueId @0 : EventId;
+  parentId @1 : EventId;
+  correlationId @2 : EventId;
+  ty @3 : EventType;
+  processId @4 : UInt32;
+  threadId @5 : UInt32;
+  timeEnabled @6 : UInt64;
+  timeRunning @7 : UInt64;
+  timestamp @8 : UInt64;
+  value @9 : UInt64;
+}

--- a/mperf-data/src/event.rs
+++ b/mperf-data/src/event.rs
@@ -88,7 +88,6 @@ impl Event {
         let message =
             serialize_packed::read_message_no_alloc(reader, &mut buf, ReaderOptions::default())?;
 
-
         let root = message.get_root::<event_capnp::event::Reader>()?;
 
         Ok(root.into())

--- a/mperf-data/src/event.rs
+++ b/mperf-data/src/event.rs
@@ -21,9 +21,32 @@ pub struct IString {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum EventType {
-    PMU,
-    LoopStart,
-    LoopEnd,
+    PmuCycles,
+    PmuInstructions,
+    PmuLlcReferences,
+    PmuLlcMisses,
+    PmuBranchInstructions,
+    PmuBranchMisses,
+    PmuStalledCyclesFrontend,
+    PmuStalledCyclesBackend,
+    PmuCustom,
+    OsCpuClock,
+    OsCpuMigrations,
+    OsPageFaults,
+    OsContextSwitches,
+    OsTotalTime,
+    OsUserTime,
+    OsSystemTime,
+    RooflineBytesLoad,
+    RooflineBytesStore,
+    RooflineScalarIntOps,
+    RooflineScalarFloatOps,
+    RooflineScalarDoubleOps,
+    RooflineVectorIntOps,
+    RooflineVectorFloatOps,
+    RooflineVectorDoubleOps,
+    RooflineLoopStart,
+    RooflineLoopEnd,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]

--- a/mperf-data/src/event.rs
+++ b/mperf-data/src/event.rs
@@ -1,17 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy)]
-#[repr(u64)]
-pub enum RooflineEventId {
-    BytesLoad,
-    BytesStore,
-    ScalarIntOps,
-    ScalarFloatOps,
-    VectorIntOps,
-    VectorFloatOps,
-    VectorDoubleOps,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IString {
     pub id: u64,
@@ -52,11 +40,10 @@ pub enum EventType {
 #[derive(Debug, Clone, Copy, Serialize)]
 #[repr(C)]
 pub struct Event {
-    pub unique_id: u64,
-    pub correlation_id: u64,
-    pub parent_id: u64,
+    pub unique_id: u128,
+    pub correlation_id: u128,
+    pub parent_id: u128,
     pub ty: EventType,
-    pub name: u64,
     pub thread_id: u32,
     pub process_id: u32,
     pub time_enabled: u64,

--- a/mperf-data/src/event_capnp.rs
+++ b/mperf-data/src/event_capnp.rs
@@ -1,3 +1,5 @@
+use crate::Event;
+
 include!(concat!(env!("OUT_DIR"), "/schema/event_capnp.rs"));
 
 impl event::Builder<'_> {
@@ -25,6 +27,31 @@ impl event::Builder<'_> {
         self.reborrow().set_time_running(event.time_running);
         self.reborrow().set_timestamp(event.timestamp);
         self.reborrow().set_value(event.value);
+    }
+}
+
+impl From<event::Reader<'_>> for Event {
+    fn from(val: event::Reader<'_>) -> Self {
+        let unique_id = ((val.get_unique_id().expect("unique_id").get_p1() as u128) << 64)
+            | ((val.get_unique_id().expect("unique_id").get_p2()) as u128);
+        let parent_id = ((val.get_parent_id().expect("parent_id").get_p1() as u128) << 64)
+            | ((val.get_parent_id().expect("parent_id").get_p2()) as u128);
+        let correlation_id = ((val.get_correlation_id().expect("correlation_id").get_p1() as u128)
+            << 64)
+            | ((val.get_correlation_id().expect("correlation_id").get_p2()) as u128);
+
+        Event {
+            unique_id,
+            correlation_id,
+            parent_id,
+            ty: val.get_ty().expect("ty").into(),
+            thread_id: val.get_thread_id(), 
+            process_id: val.get_process_id(),
+            time_enabled: val.get_time_enabled(),
+            time_running: val.get_time_running(),
+            value: val.get_value(),
+            timestamp: val.get_timestamp(),
+        }
     }
 }
 
@@ -57,6 +84,39 @@ impl From<crate::EventType> for EventType {
             crate::EventType::RooflineVectorDoubleOps => EventType::RooflineVectorDoubleOps,
             crate::EventType::RooflineLoopStart => EventType::RooflineLoopStart,
             crate::EventType::RooflineLoopEnd => EventType::RooflineLoopEnd,
+        }
+    }
+}
+
+impl From<EventType> for crate::EventType {
+    fn from(value: EventType) -> Self {
+        match value {
+            EventType::PmuCycles => crate::EventType::PmuCycles,
+            EventType::PmuInstructions => crate::EventType::PmuInstructions,
+            EventType::PmuLLCReferences => crate::EventType::PmuLlcReferences,
+            EventType::PmuLLCMisses => crate::EventType::PmuLlcMisses,
+            EventType::PmuBranchInstructions => crate::EventType::PmuBranchInstructions,
+            EventType::PmuBranchMisses => crate::EventType::PmuBranchMisses,
+            EventType::PmuStalledCyclesFrontend => crate::EventType::PmuStalledCyclesFrontend,
+            EventType::PmuStalledCyclesBackend => crate::EventType::PmuStalledCyclesBackend,
+            EventType::PmuCustom => crate::EventType::PmuCustom,
+            EventType::OsCpuClock => crate::EventType::OsCpuClock,
+            EventType::OsCpuMigrations => crate::EventType::OsCpuMigrations,
+            EventType::OsPageFaults => crate::EventType::OsPageFaults,
+            EventType::OsContextSwitches => crate::EventType::OsContextSwitches,
+            EventType::OsTotalTime => crate::EventType::OsTotalTime,
+            EventType::OsUserTime => crate::EventType::OsUserTime,
+            EventType::OsSystemTime => crate::EventType::OsSystemTime,
+            EventType::RooflineBytesLoad => crate::EventType::RooflineBytesLoad,
+            EventType::RooflineBytesStore => crate::EventType::RooflineBytesStore,
+            EventType::RooflineScalarIntOps => crate::EventType::RooflineScalarIntOps,
+            EventType::RooflineScalarFloatOps => crate::EventType::RooflineScalarFloatOps,
+            EventType::RooflineScalarDoubleOps => crate::EventType::RooflineScalarDoubleOps,
+            EventType::RooflineVectorIntOps => crate::EventType::RooflineVectorIntOps,
+            EventType::RooflineVectorFloatOps => crate::EventType::RooflineVectorFloatOps,
+            EventType::RooflineVectorDoubleOps => crate::EventType::RooflineVectorDoubleOps,
+            EventType::RooflineLoopStart => crate::EventType::RooflineLoopStart,
+            EventType::RooflineLoopEnd => crate::EventType::RooflineLoopEnd,
         }
     }
 }

--- a/mperf-data/src/event_capnp.rs
+++ b/mperf-data/src/event_capnp.rs
@@ -1,21 +1,21 @@
 include!(concat!(env!("OUT_DIR"), "/schema/event_capnp.rs"));
 
-impl<'a> event::Builder<'a> {
+impl event::Builder<'_> {
     pub fn set_event(&mut self, event: &crate::Event) {
         {
             let mut unique_id = self.reborrow().init_unique_id();
-            unique_id.set_p1(0);
-            unique_id.set_p2(event.unique_id);
+            unique_id.set_p1((event.unique_id >> 64) as u64);
+            unique_id.set_p2(event.unique_id as u64);
         }
         {
             let mut parent_id = self.reborrow().init_parent_id();
-            parent_id.set_p1(0);
-            parent_id.set_p2(event.parent_id);
+            parent_id.set_p1((event.parent_id >> 64) as u64);
+            parent_id.set_p2(event.parent_id as u64);
         }
         {
             let mut correlation_id = self.reborrow().init_correlation_id();
-            correlation_id.set_p1(0);
-            correlation_id.set_p2(event.correlation_id);
+            correlation_id.set_p1((event.correlation_id >> 64) as u64);
+            correlation_id.set_p2(event.correlation_id as u64);
         }
 
         self.reborrow().set_ty(event.ty.into());

--- a/mperf-data/src/event_capnp.rs
+++ b/mperf-data/src/event_capnp.rs
@@ -45,7 +45,7 @@ impl From<event::Reader<'_>> for Event {
             correlation_id,
             parent_id,
             ty: val.get_ty().expect("ty").into(),
-            thread_id: val.get_thread_id(), 
+            thread_id: val.get_thread_id(),
             process_id: val.get_process_id(),
             time_enabled: val.get_time_enabled(),
             time_running: val.get_time_running(),

--- a/mperf-data/src/event_capnp.rs
+++ b/mperf-data/src/event_capnp.rs
@@ -1,0 +1,62 @@
+include!(concat!(env!("OUT_DIR"), "/schema/event_capnp.rs"));
+
+impl<'a> event::Builder<'a> {
+    pub fn set_event(&mut self, event: &crate::Event) {
+        {
+            let mut unique_id = self.reborrow().init_unique_id();
+            unique_id.set_p1(0);
+            unique_id.set_p2(event.unique_id);
+        }
+        {
+            let mut parent_id = self.reborrow().init_parent_id();
+            parent_id.set_p1(0);
+            parent_id.set_p2(event.parent_id);
+        }
+        {
+            let mut correlation_id = self.reborrow().init_correlation_id();
+            correlation_id.set_p1(0);
+            correlation_id.set_p2(event.correlation_id);
+        }
+
+        self.reborrow().set_ty(event.ty.into());
+        self.reborrow().set_process_id(event.process_id);
+        self.reborrow().set_thread_id(event.thread_id);
+        self.reborrow().set_time_enabled(event.time_enabled);
+        self.reborrow().set_time_running(event.time_running);
+        self.reborrow().set_timestamp(event.timestamp);
+        self.reborrow().set_value(event.value);
+    }
+}
+
+impl From<crate::EventType> for EventType {
+    fn from(value: crate::EventType) -> Self {
+        match value {
+            crate::EventType::PmuCycles => EventType::PmuCycles,
+            crate::EventType::PmuInstructions => EventType::PmuInstructions,
+            crate::EventType::PmuLlcReferences => EventType::PmuLLCReferences,
+            crate::EventType::PmuLlcMisses => EventType::PmuLLCMisses,
+            crate::EventType::PmuBranchInstructions => EventType::PmuBranchInstructions,
+            crate::EventType::PmuBranchMisses => EventType::PmuBranchMisses,
+            crate::EventType::PmuStalledCyclesFrontend => EventType::PmuStalledCyclesFrontend,
+            crate::EventType::PmuStalledCyclesBackend => EventType::PmuStalledCyclesBackend,
+            crate::EventType::PmuCustom => EventType::PmuCustom,
+            crate::EventType::OsCpuClock => EventType::OsCpuClock,
+            crate::EventType::OsCpuMigrations => EventType::OsCpuMigrations,
+            crate::EventType::OsPageFaults => EventType::OsPageFaults,
+            crate::EventType::OsContextSwitches => EventType::OsContextSwitches,
+            crate::EventType::OsTotalTime => EventType::OsTotalTime,
+            crate::EventType::OsUserTime => EventType::OsUserTime,
+            crate::EventType::OsSystemTime => EventType::OsSystemTime,
+            crate::EventType::RooflineBytesLoad => EventType::RooflineBytesLoad,
+            crate::EventType::RooflineBytesStore => EventType::RooflineBytesStore,
+            crate::EventType::RooflineScalarIntOps => EventType::RooflineScalarIntOps,
+            crate::EventType::RooflineScalarFloatOps => EventType::RooflineScalarFloatOps,
+            crate::EventType::RooflineScalarDoubleOps => EventType::RooflineScalarDoubleOps,
+            crate::EventType::RooflineVectorIntOps => EventType::RooflineVectorIntOps,
+            crate::EventType::RooflineVectorFloatOps => EventType::RooflineVectorFloatOps,
+            crate::EventType::RooflineVectorDoubleOps => EventType::RooflineVectorDoubleOps,
+            crate::EventType::RooflineLoopStart => EventType::RooflineLoopStart,
+            crate::EventType::RooflineLoopEnd => EventType::RooflineLoopEnd,
+        }
+    }
+}

--- a/mperf-data/src/lib.rs
+++ b/mperf-data/src/lib.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 mod event;
 pub(crate) mod event_capnp;
 
-pub use event::{Event, EventType, IString, ProcMap, ProcMapEntry, RooflineEventId};
+pub use event::{Event, EventType, IString, ProcMap, ProcMapEntry};
 
 #[derive(Clone, Debug, Copy, ValueEnum, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Scenario {

--- a/mperf-data/src/lib.rs
+++ b/mperf-data/src/lib.rs
@@ -2,6 +2,7 @@ use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
 mod event;
+pub(crate) mod event_capnp;
 
 pub use event::{Event, EventType, IString, ProcMap, ProcMapEntry, RooflineEventId};
 

--- a/mperf/Cargo.toml
+++ b/mperf/Cargo.toml
@@ -22,3 +22,5 @@ tokio-stream = "0.1.17"
 memmap2 = "0.9.5"
 serde-jsonlines = "0.6.0"
 shmem = { path = "../shmem" }
+thread_local = "1.1.8"
+libc = "0.2.169"

--- a/mperf/src/event_dispatcher.rs
+++ b/mperf/src/event_dispatcher.rs
@@ -43,8 +43,10 @@ impl EventDispatcher {
         let mut events_token = cancel_rx.clone();
         let events_out_dir = output_directory.to_owned();
         let events_worker = tokio::spawn(async move {
-            let mut events_file = std::io::BufWriter::new(std::fs::File::create(events_out_dir.join("events.bin"))
-                .expect("event file stream creation"));
+            let mut events_file = std::io::BufWriter::new(
+                std::fs::File::create(events_out_dir.join("events.bin"))
+                    .expect("event file stream creation"),
+            );
             loop {
                 tokio::select! {
                     _ = events_token.changed() => {

--- a/mperf/src/event_dispatcher.rs
+++ b/mperf/src/event_dispatcher.rs
@@ -125,7 +125,7 @@ impl EventDispatcher {
     }
 
     pub fn unique_id(&self) -> u128 {
-        let mut counter = self.last_unique_id.get().unwrap().borrow_mut();
+        let mut counter = self.last_unique_id.get_or(|| RefCell::new(0)).borrow_mut();
         let id = ((std::process::id() as u128) << 96) | ((unsafe { libc::gettid() } as u128) << 64) | (*counter as u128);
         *counter += 1;
         id

--- a/mperf/src/event_dispatcher.rs
+++ b/mperf/src/event_dispatcher.rs
@@ -126,7 +126,9 @@ impl EventDispatcher {
 
     pub fn unique_id(&self) -> u128 {
         let mut counter = self.last_unique_id.get_or(|| RefCell::new(0)).borrow_mut();
-        let id = ((std::process::id() as u128) << 96) | ((unsafe { libc::gettid() } as u128) << 64) | (*counter as u128);
+        let id = ((std::process::id() as u128) << 96)
+            | ((unsafe { libc::gettid() } as u128) << 64)
+            | (*counter as u128);
         *counter += 1;
         id
     }

--- a/mperf/src/main.rs
+++ b/mperf/src/main.rs
@@ -2,6 +2,7 @@ mod event_dispatcher;
 mod record;
 mod stat;
 mod tui;
+mod utils;
 
 use std::{
     path::{Path, PathBuf},

--- a/mperf/src/tui/mod.rs
+++ b/mperf/src/tui/mod.rs
@@ -249,17 +249,6 @@ impl SummaryTab {
             };
         }
 
-        // let events = unsafe {
-        //     std::slice::from_raw_parts(
-        //         map.as_ptr() as *const Event,
-        //         map.len() / std::mem::size_of::<Event>(),
-        //     )
-        // };
-
-        // for (i, evt) in events.iter().enumerate() {
-        //
-        // }
-
         {
             let mut cntr = self.counter.write();
             *cntr = 50;

--- a/mperf/src/tui/mod.rs
+++ b/mperf/src/tui/mod.rs
@@ -7,7 +7,7 @@ use std::{
 use anyhow::Result;
 use crossterm::event::{EventStream, KeyCode, KeyEventKind};
 use memmap2::{Advice, Mmap};
-use mperf_data::{Event, EventType, IString, RecordInfo, Scenario};
+use mperf_data::{Event, EventType, RecordInfo, Scenario};
 use num_format::{Locale, ToFormattedString};
 use parking_lot::RwLock;
 use ratatui::{

--- a/mperf/src/tui/mod.rs
+++ b/mperf/src/tui/mod.rs
@@ -214,9 +214,7 @@ impl SummaryTab {
         map.advise(Advice::Sequential)
             .expect("Failed to advice sequential reads");
 
-        let data_stream = unsafe {
-            std::slice::from_raw_parts(map.as_ptr(), map.len())
-        };
+        let data_stream = unsafe { std::slice::from_raw_parts(map.as_ptr(), map.len()) };
 
         let mut cursor = std::io::Cursor::new(data_stream);
 
@@ -257,7 +255,6 @@ impl SummaryTab {
         //         map.len() / std::mem::size_of::<Event>(),
         //     )
         // };
-
 
         // for (i, evt) in events.iter().enumerate() {
         //

--- a/mperf/src/tui/mod.rs
+++ b/mperf/src/tui/mod.rs
@@ -7,7 +7,7 @@ use std::{
 use anyhow::Result;
 use crossterm::event::{EventStream, KeyCode, KeyEventKind};
 use memmap2::{Advice, Mmap};
-use mperf_data::{Event, IString, RecordInfo, Scenario};
+use mperf_data::{Event, EventType, IString, RecordInfo, Scenario};
 use num_format::{Locale, ToFormattedString};
 use parking_lot::RwLock;
 use ratatui::{
@@ -17,7 +17,6 @@ use ratatui::{
     widgets::{Block, Gauge, Row, Table, Tabs, Widget},
     DefaultTerminal, Frame,
 };
-use serde_jsonlines::json_lines;
 use tokio::fs::{self, File};
 use tokio_stream::StreamExt;
 
@@ -215,52 +214,6 @@ impl SummaryTab {
         map.advise(Advice::Sequential)
             .expect("Failed to advice sequential reads");
 
-        let strings: Vec<IString> = json_lines(self.res_dir.join("strings.jsonl"))
-            .expect("failed to read or parse strings.jsonl")
-            .collect::<Result<_, _>>()
-            .expect("failed to parse strings");
-
-        let cycles = strings
-            .iter()
-            .find(|istr| istr.value == "cycles")
-            .map(|istr| istr.id)
-            .unwrap_or(u64::MAX);
-        let instruction = strings
-            .iter()
-            .find(|istr| istr.value == "instructions")
-            .map(|istr| istr.id)
-            .unwrap_or(u64::MAX);
-        let llc_references = strings
-            .iter()
-            .find(|istr| istr.value == "llc_references")
-            .map(|istr| istr.id)
-            .unwrap_or(u64::MAX);
-        let llc_misses = strings
-            .iter()
-            .find(|istr| istr.value == "llc_misses")
-            .map(|istr| istr.id)
-            .unwrap_or(u64::MAX);
-        let branches = strings
-            .iter()
-            .find(|istr| istr.value == "branches")
-            .map(|istr| istr.id)
-            .unwrap_or(u64::MAX);
-        let branch_misses = strings
-            .iter()
-            .find(|istr| istr.value == "branch_misses")
-            .map(|istr| istr.id)
-            .unwrap_or(u64::MAX);
-        let stalled_cycles_frontend = strings
-            .iter()
-            .find(|istr| istr.value == "stalled_cycles_frontend")
-            .map(|istr| istr.id)
-            .unwrap_or(u64::MAX);
-        let stalled_cycles_backend = strings
-            .iter()
-            .find(|istr| istr.value == "stalled_cycles_backend")
-            .map(|istr| istr.id)
-            .unwrap_or(u64::MAX);
-
         let events = unsafe {
             std::slice::from_raw_parts(
                 map.as_ptr() as *const Event,
@@ -283,23 +236,17 @@ impl SummaryTab {
             let value =
                 (evt.value as f64 * (evt.time_enabled as f64 / evt.time_running as f64)) as u64;
 
-            if evt.name == cycles {
-                stat.cycles += value;
-            } else if evt.name == instruction {
-                stat.instructions += value;
-            } else if evt.name == llc_references {
-                stat.cache_references += value;
-            } else if evt.name == llc_misses {
-                stat.cache_misses += value;
-            } else if evt.name == branches {
-                stat.branch_instructions += value;
-            } else if evt.name == branch_misses {
-                stat.branch_misses += value;
-            } else if evt.name == stalled_cycles_frontend {
-                stat.stalled_cycles_frontend += value;
-            } else if evt.name == stalled_cycles_backend {
-                stat.stalled_cycles_backend += value;
-            }
+            match evt.ty {
+                EventType::PmuCycles => { stat.cycles += value },
+                EventType::PmuInstructions => { stat.instructions += value},
+                EventType::PmuLlcReferences => { stat.cache_references += value},
+                EventType::PmuLlcMisses => { stat.cache_misses += value},
+                EventType::PmuBranchMisses => { stat.branch_misses += value},
+                EventType::PmuBranchInstructions => { stat.branch_instructions += value},
+                EventType::PmuStalledCyclesBackend => { stat.stalled_cycles_backend += value},
+                EventType::PmuStalledCyclesFrontend => { stat.stalled_cycles_frontend += value},
+                _ => {},
+            };
         }
 
         {

--- a/mperf/src/tui/mod.rs
+++ b/mperf/src/tui/mod.rs
@@ -237,15 +237,15 @@ impl SummaryTab {
                 (evt.value as f64 * (evt.time_enabled as f64 / evt.time_running as f64)) as u64;
 
             match evt.ty {
-                EventType::PmuCycles => { stat.cycles += value },
-                EventType::PmuInstructions => { stat.instructions += value},
-                EventType::PmuLlcReferences => { stat.cache_references += value},
-                EventType::PmuLlcMisses => { stat.cache_misses += value},
-                EventType::PmuBranchMisses => { stat.branch_misses += value},
-                EventType::PmuBranchInstructions => { stat.branch_instructions += value},
-                EventType::PmuStalledCyclesBackend => { stat.stalled_cycles_backend += value},
-                EventType::PmuStalledCyclesFrontend => { stat.stalled_cycles_frontend += value},
-                _ => {},
+                EventType::PmuCycles => stat.cycles += value,
+                EventType::PmuInstructions => stat.instructions += value,
+                EventType::PmuLlcReferences => stat.cache_references += value,
+                EventType::PmuLlcMisses => stat.cache_misses += value,
+                EventType::PmuBranchMisses => stat.branch_misses += value,
+                EventType::PmuBranchInstructions => stat.branch_instructions += value,
+                EventType::PmuStalledCyclesBackend => stat.stalled_cycles_backend += value,
+                EventType::PmuStalledCyclesFrontend => stat.stalled_cycles_frontend += value,
+                _ => {}
             };
         }
 

--- a/mperf/src/utils.rs
+++ b/mperf/src/utils.rs
@@ -1,0 +1,16 @@
+use mperf_data::EventType;
+use pmu::Counter;
+
+pub fn counter_to_event_ty(counter: &Counter) -> EventType {
+    match counter {
+        Counter::Cycles => EventType::PmuCycles,
+        Counter::Instructions => EventType::PmuInstructions,
+        Counter::LLCReferences => EventType::PmuLlcReferences,
+        Counter::LLCMisses => EventType::PmuLlcMisses,
+        Counter::BranchInstructions => EventType::PmuBranchInstructions,
+        Counter::BranchMisses => EventType::PmuBranchMisses,
+        Counter::StalledCyclesFrontend => EventType::PmuStalledCyclesFrontend,
+        Counter::StalledCyclesBackend => EventType::PmuStalledCyclesBackend,
+        Counter::Custom(_) => EventType::PmuCustom,
+    }
+}


### PR DESCRIPTION
Cap'n'Proto demonstrates better data compression and allows easier data interchange between different languages. Also make several data structure changes:
1. IDs are now 128 bits to allow for parallel ID generation without collisions
2. Event types have been updated to reduce the number of strings required for storage