### PR TITLE
feat: add infrastructure for custom PMU counters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = [ "collector", "mperf", "mperf-data", "pmu"]
+members = [ "collector", "mperf", "mperf-data", "pmu", "pmu-data"]

--- a/collector/src/ffi.rs
+++ b/collector/src/ffi.rs
@@ -11,7 +11,7 @@ use crate::{get_next_id, profiling_enabled, roofline_instrumentation_enabled, se
 #[repr(C)]
 pub struct LoopInfo {
     line: u32,
-    filename: *const i8,
+    filename: *const libc::c_char,
 }
 
 #[derive(Debug, Clone)]

--- a/mperf/src/main.rs
+++ b/mperf/src/main.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
             return do_stat(command);
         }
         Commands::List => {
-            let events = pmu::list_counters();
+            let events = pmu::list_supported_counters();
             for event in events {
                 println!("{} - {}", event.name(), event.description());
             }

--- a/mperf/src/stat.rs
+++ b/mperf/src/stat.rs
@@ -16,6 +16,10 @@ pub fn do_stat(command: Vec<String>) -> Result<()> {
             Counter::BranchInstructions,
             Counter::StalledCyclesBackend,
             Counter::StalledCyclesFrontend,
+            Counter::CpuClock,
+            Counter::CpuMigrations,
+            Counter::PageFaults,
+            Counter::ContextSwitches,
         ],
         Some(&process),
     )?;

--- a/mperf/src/utils.rs
+++ b/mperf/src/utils.rs
@@ -17,7 +17,12 @@ pub fn counter_to_event_ty(counter: &Counter) -> EventType {
         Counter::BranchMisses => EventType::PmuBranchMisses,
         Counter::StalledCyclesFrontend => EventType::PmuStalledCyclesFrontend,
         Counter::StalledCyclesBackend => EventType::PmuStalledCyclesBackend,
+        Counter::CpuClock => EventType::OsCpuClock,
+        Counter::PageFaults => EventType::OsPageFaults,
+        Counter::CpuMigrations => EventType::OsCpuMigrations,
+        Counter::ContextSwitches => EventType::OsContextSwitches,
         Counter::Custom(_) => EventType::PmuCustom,
+        Counter::Internal{name: _, desc: _, code: _} => EventType::PmuCustom,
     }
 }
 

--- a/mperf/src/utils.rs
+++ b/mperf/src/utils.rs
@@ -22,7 +22,11 @@ pub fn counter_to_event_ty(counter: &Counter) -> EventType {
         Counter::CpuMigrations => EventType::OsCpuMigrations,
         Counter::ContextSwitches => EventType::OsContextSwitches,
         Counter::Custom(_) => EventType::PmuCustom,
-        Counter::Internal{name: _, desc: _, code: _} => EventType::PmuCustom,
+        Counter::Internal {
+            name: _,
+            desc: _,
+            code: _,
+        } => EventType::PmuCustom,
     }
 }
 

--- a/pmu-data/Cargo.toml
+++ b/pmu-data/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "pmu-data"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0.217", features = ["derive"] }

--- a/pmu-data/src/lib.rs
+++ b/pmu-data/src/lib.rs
@@ -1,0 +1,84 @@
+use serde::{de, Deserialize, Serialize};
+
+// Well-known CPU families
+pub const AMDZEN1: &str = "zen1";
+pub const AMDZEN2: &str = "zen2";
+pub const AMDZEN3: &str = "zen3";
+pub const AMDZEN4: &str = "zen4";
+
+pub const INTEL_HASWELL: &str = "haswell";
+pub const INTEL_BROADWELL: &str = "broadwell";
+pub const INTEL_SKYLAKE: &str = "skylake";
+pub const INTEL_KABYLAKE: &str = "kabylake";
+pub const INTEL_COMETLAKE: &str = "cometlake";
+pub const INTEL_ICELAKE: &str = "icelake";
+// a.k.a. Ice Lake Server
+pub const INTEL_ICX: &str = "icx";
+pub const INTEL_TIGERLAKE: &str = "tigerlake";
+pub const INTEL_ROCKETLAKE: &str = "rocketlake";
+pub const INTEL_ALDERLAKE: &str = "alderlake";
+pub const INTEL_RAPTORLAKE: &str = "raptorlake";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PlatformDesc {
+    pub family_id: String,
+    pub name: String,
+    pub vendor: String,
+    pub arch: String,
+    pub events: Vec<EventDesc>,
+    pub aliases: Option<Vec<Alias>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EventDesc {
+    pub name: String,
+    pub desc: String,
+    #[serde(serialize_with = "serialize_hex", deserialize_with = "deserialize_hex")]
+    pub code: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Alias {
+    from: String,
+    to: String,
+}
+
+fn serialize_hex<S>(v: &u64, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let string = format!("0x{:X}", v);
+    serializer.serialize_str(&string)
+}
+
+fn deserialize_hex<'a, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'a>,
+{
+    struct Visitor;
+
+    impl de::Visitor<'_> for Visitor {
+        type Value = u64;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a string containing a hexadecimal number starting with '0x'")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            if !v.starts_with("0x") {
+                return Err(E::custom("does not start with '0x'"));
+            }
+
+            let hex_only = &v[2..];
+            match u64::from_str_radix(hex_only, 16) {
+                Ok(value) => Ok(value),
+                Err(err) => Err(E::custom(err)),
+            }
+        }
+    }
+
+    deserializer.deserialize_str(Visitor)
+}

--- a/pmu-data/src/lib.rs
+++ b/pmu-data/src/lib.rs
@@ -41,8 +41,8 @@ pub struct EventDesc {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Alias {
-    from: String,
-    to: String,
+    target: String,
+    origin: String,
 }
 
 fn serialize_hex<S>(v: &u64, serializer: S) -> Result<S::Ok, S::Error>

--- a/pmu-data/src/lib.rs
+++ b/pmu-data/src/lib.rs
@@ -19,6 +19,8 @@ pub const INTEL_ROCKETLAKE: &str = "rocketlake";
 pub const INTEL_ALDERLAKE: &str = "alderlake";
 pub const INTEL_RAPTORLAKE: &str = "raptorlake";
 
+pub const SIFIVE_U7: &str = "sifive_u7";
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PlatformDesc {
     pub family_id: String,

--- a/pmu/Cargo.toml
+++ b/pmu/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 cfg-if = "1.0.0"
 libc = "0.2.144"
 thiserror = "2.0.9"
+pmu-data = { path = "../pmu-data/" }
+lazy_static = "1.5.0"
 
 [target.'cfg(unix)'.dependencies]
 proc_getter = "0.0.3"
@@ -14,3 +16,12 @@ dlopen2 = "0.7.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 perf-event-open-sys2 = "5.0.6"
+
+[build-dependencies]
+serde = "1.0.217"
+serde_json = "1.0.138"
+pmu-data = { path = "../pmu-data/" }
+glob = "0.3.2"
+quote = "1.0.38"
+prettyplease = "0.2.29"
+syn = "2.0.96"

--- a/pmu/build.rs
+++ b/pmu/build.rs
@@ -1,0 +1,87 @@
+use std::{
+    error::Error,
+    fs::{self, File},
+};
+
+use glob::glob;
+use pmu_data::PlatformDesc;
+use quote::quote;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo:rerun-if-changed=events/");
+
+    let mut families = vec![];
+    for entry in glob("events/**/*.json")? {
+        let path = entry?;
+        println!("cargo:rerun-if-changed={}", path.display());
+
+        let file = File::open(path)?;
+        let data: PlatformDesc = serde_json::from_reader(file)?;
+
+        let arch = std::env::var("CARGO_CFG_TARGET_ARCH")?;
+
+        if arch != data.arch {
+            continue;
+        }
+
+        let mut events = vec![];
+
+        for evt in data.events {
+            let name = &evt.name;
+            let desc = &evt.desc;
+            let code = evt.code;
+            events.push(quote! {
+                events.insert(#name.to_string(), EventDesc {
+                    name: #name.to_string(),
+                    desc: #desc.to_string(),
+                    code: #code
+                });
+            });
+        }
+
+        let name = &data.name;
+        let vendor = &data.vendor;
+        let family_id = &data.family_id;
+
+        families.push(quote! {
+            let mut events = HashMap::new();
+            #(#events)*
+
+            let mut aliases = HashMap::new();
+
+            let family = CPUFamily {
+                name: #name.to_string(),
+                vendor: #vendor.to_string(),
+                id: #family_id.to_string(),
+                events,
+                aliases,
+            };
+
+            families.insert(#family_id.to_string(), family);
+        });
+    }
+
+    let all_events = quote! {
+        lazy_static! {
+            static ref CPU_FAMILIES: HashMap<String, CPUFamily> = create_known_counters_map();
+        }
+
+        fn create_known_counters_map() -> HashMap<String, CPUFamily> {
+            let mut families = HashMap::new();
+
+            #(#families)*
+
+            families
+        }
+    };
+
+    let file = syn::parse2(all_events)?;
+    let formatted = prettyplease::unparse(&file);
+
+    fs::write(
+        format!("{}/events.rs", std::env::var("OUT_DIR")?),
+        formatted,
+    )?;
+
+    Ok(())
+}

--- a/pmu/events/amd/zen1.json
+++ b/pmu/events/amd/zen1.json
@@ -1,0 +1,13 @@
+{
+  "family_id": "zen1",
+  "name": "AMD Zen or Zen+ architecture",
+  "vendor": "AMD",
+  "arch": "x86_64",
+  "events": [
+    {
+      "name": "ex_ret_instr",
+      "desc": "Retired Instructions",
+      "code": "0xc0"
+    }
+  ]
+}

--- a/pmu/events/sifive/u7.json
+++ b/pmu/events/sifive/u7.json
@@ -1,0 +1,98 @@
+{
+  "family_id": "sifive_u7",
+  "name": "SiFive U7 series",
+  "vendor": "SiFive",
+  "arch": "riscv64",
+  "events": [
+    {
+      "name": "EXCEPTION_TAKEN",
+      "desc": "Exception taken",
+      "code": "0x0000100"
+    },
+    {
+      "name": "INTEGER_LOAD_RETIRED",
+      "desc": "Integer load instruction retired",
+      "code": "0x0000200"
+    },
+    {
+      "name": "INTEGER_STORE_RETIRED",
+      "desc": "Integer store instruction retired",
+      "code": "0x0000400"
+    },
+    {
+      "name": "ATOMIC_MEMORY_RETIRED",
+      "desc": "Atomic memory operation retired",
+      "code": "0x0000800"
+    },
+    {
+      "name": "SYSTEM_INSTRUCTION_RETIRED",
+      "desc": "System instruction retired",
+      "code": "0x0001000"
+    },
+    {
+      "name": "INTEGER_ARITHMETIC_RETIRED",
+      "desc": "Integer arithmetic instruction retired",
+      "code": "0x0002000"
+    },
+    {
+      "name": "CONDITIONAL_BRANCH_RETIRED",
+      "desc": "Conditional branch retired",
+      "code": "0x0004000"
+    },
+    {
+      "name": "JAL_INSTRUCTION_RETIRED",
+      "desc": "JAL instruction retired",
+      "code": "0x0008000"
+    },
+    {
+      "name": "JALR_INSTRUCTION_RETIRED",
+      "desc": "JALR instruction retired",
+      "code": "0x0010000"
+    },
+    {
+      "name": "INTEGER_MULTIPLICATION_RETIRED",
+      "desc": "Integer multiplication instruction retired",
+      "code": "0x0020000"
+    },
+    {
+      "name": "INTEGER_DIVISION_RETIRED",
+      "desc": "Integer division instruction retired",
+      "code": "0x0040000"
+    },
+    {
+      "name": "FP_LOAD_RETIRED",
+      "desc": "Floating-point load instruction retired",
+      "code": "0x0080000"
+    },
+    {
+      "name": "FP_STORE_RETIRED",
+      "desc": "Floating-point store instruction retired",
+      "code": "0x0100000"
+    },
+    {
+      "name": "FP_ADDITION_RETIRED",
+      "desc": "Floating-point addition retired",
+      "code": "0x0200000"
+    },
+    {
+      "name": "FP_MULTIPLICATION_RETIRED",
+      "desc": "Floating-point multiplication retired",
+      "code": "0x0400000"
+    },
+    {
+      "name": "FP_FUSEDMADD_RETIRED",
+      "desc": "Floating-point fused multiply-add retired",
+      "code": "0x0800000"
+    },
+    {
+      "name": "FP_DIV_SQRT_RETIRED",
+      "desc": "Floating-point division or square-root retired",
+      "code": "0x1000000"
+    },
+    {
+      "name": "OTHER_FP_RETIRED",
+      "desc": "Other floating-point instruction retired",
+      "code": "0x2000000"
+    }
+  ]
+}

--- a/pmu/events/sifive/u7.json
+++ b/pmu/events/sifive/u7.json
@@ -3,6 +3,20 @@
   "name": "SiFive U7 series",
   "vendor": "SiFive",
   "arch": "riscv64",
+  "aliases": [
+    {
+      "target": "branches",
+      "origin": "CONDITIONAL_BRANCH_RETIRED"
+    },
+    {
+      "target": "branch_misses",
+      "origin": "BRANCH_DIRECTION_MISPRED"
+    },
+    {
+      "target": "cache_misses",
+      "origin": "DCACHE_MISS_MMIO_ACCESSES"
+    }
+  ],
   "events": [
     {
       "name": "EXCEPTION_TAKEN",
@@ -93,6 +107,91 @@
       "name": "OTHER_FP_RETIRED",
       "desc": "Other floating-point instruction retired",
       "code": "0x2000000"
+    },
+    {
+      "name": "ICACHE_RETIRED",
+      "desc": "Instruction cache miss",
+      "code": "0x0000102"
+    },
+    {
+      "name": "DCACHE_MISS_MMIO_ACCESSES",
+      "desc": "Data cache miss or memory-mapped I/O access",
+      "code": "0x0000202"
+    },
+    {
+      "name": "DCACHE_WRITEBACK",
+      "desc": "Data cache write-back",
+      "code": "0x0000402"
+    },
+    {
+      "name": "INST_TLB_MISS",
+      "desc": "Instruction TLB miss",
+      "code": "0x0000802"
+    },
+    {
+      "name": "DATA_TLB_MISS",
+      "desc": "Data TLB miss",
+      "code": "0x0001002"
+    },
+    {
+      "name": "UTLB_MISS",
+      "desc": "UTLB miss",
+      "code": "0x0002002"
+    },
+    {
+      "name": "ADDRESSGEN_INTERLOCK",
+      "desc": "Address-generation interlock",
+      "code": "0x0000101"
+    },
+    {
+      "name": "LONGLAT_INTERLOCK",
+      "desc": "Long-latency interlock",
+      "code": "0x0000201"
+    },
+    {
+      "name": "CSR_READ_INTERLOCK",
+      "desc": "CSR read interlock",
+      "code": "0x0000401"
+    },
+    {
+      "name": "ICACHE_ITIM_BUSY",
+      "desc": "Instruction cache/ITIM busy",
+      "code": "0x0000801"
+    },
+    {
+      "name": "DCACHE_DTIM_BUSY",
+      "desc": "Data cache/DTIM busy",
+      "code": "0x0001001"
+    },
+    {
+      "name": "BRANCH_DIRECTION_MISPREDICTION",
+      "desc": "Branch direction misprediction",
+      "code": "0x0002001"
+    },
+    {
+      "name": "BRANCH_TARGET_MISPREDICTION",
+      "desc": "Branch/jump target misprediction",
+      "code": "0x0004001"
+    },
+    {
+      "name": "PIPE_FLUSH_CSR_WRITE",
+      "desc": "Pipeline flush from CSR write",
+      "code": "0x0008001"
+    },
+    {
+      "name": "PIPE_FLUSH_OTHER_EVENT",
+      "desc": "Pipeline flush from other event",
+      "code": "0x0010001"
+    },
+    {
+      "name": "INTEGER_MULTIPLICATION_INTERLOCK",
+      "desc": "Integer multiplication interlock",
+      "code": "0x0020001"
+    },
+    {
+      "name": "FP_INTERLOCK",
+      "desc": "Floating-point interlock",
+      "code": "0x0040001"
     }
   ]
 }

--- a/pmu/src/cpu_family.rs
+++ b/pmu/src/cpu_family.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use lazy_static::lazy_static;
 use pmu_data::EventDesc;
 
+#[allow(dead_code)]
 pub struct CPUFamily {
     pub name: String,
     pub vendor: String,
@@ -62,11 +63,9 @@ pub fn get_host_cpu_family() -> &'static str {
         } else if (extended_model == 0x3 && model == 0xd) || (extended_model == 0x4 && model == 0x7)
         {
             return pmu_data::INTEL_BROADWELL;
-        } else if (extended_model == 0x5 && model == 0xe) || (extended_model == 0x4 && model == 0xe)
-        {
+        } else if model == 0xe && (extended_model == 0x5 || extended_model == 0x4) {
             return pmu_data::INTEL_SKYLAKE;
-        } else if (extended_model == 0x8 && model == 0xe) || (extended_model == 0x9 && model == 0xe)
-        {
+        } else if model == 0xe && (extended_model == 0x8 || extended_model == 0x9) {
             return pmu_data::INTEL_KABYLAKE;
         } else if extended_model == 0xa && model == 0x5 {
             return pmu_data::INTEL_COMETLAKE;

--- a/pmu/src/cpu_family.rs
+++ b/pmu/src/cpu_family.rs
@@ -89,7 +89,7 @@ pub fn get_host_cpu_family() -> &'static str {
 }
 
 #[cfg(target_arch = "riscv64")]
-fn get_cpu_family() -> ProcessorFamily {
+fn get_host_cpu_family() -> ProcessorFamily {
     use proc_getter::cpuinfo::cpuinfo;
 
     let info = cpuinfo().expect("/proc/cpuinfo is inaccessible");

--- a/pmu/src/cpu_family.rs
+++ b/pmu/src/cpu_family.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+
+use lazy_static::lazy_static;
+use pmu_data::{
+    EventDesc, AMDZEN1, AMDZEN2, AMDZEN3, AMDZEN4, INTEL_ALDERLAKE, INTEL_BROADWELL,
+    INTEL_COMETLAKE, INTEL_HASWELL, INTEL_ICELAKE, INTEL_ICX, INTEL_KABYLAKE, INTEL_RAPTORLAKE,
+    INTEL_ROCKETLAKE, INTEL_SKYLAKE, INTEL_TIGERLAKE,
+};
+
+pub struct CPUFamily {
+    pub name: String,
+    pub vendor: String,
+    pub id: String,
+    pub events: HashMap<String, EventDesc>,
+    pub aliases: HashMap<String, String>,
+}
+
+include!(concat!(env!("OUT_DIR"), "/events.rs"));
+
+pub fn find_cpu_family(id: &str) -> Option<&CPUFamily> {
+    CPU_FAMILIES.get(id)
+}
+
+#[cfg(target_arch = "x86_64")]
+pub fn get_host_cpu_family() -> &'static str {
+    const EAX_VENDOR_INFO: u32 = 0x1;
+
+    let result = unsafe { core::arch::x86_64::__cpuid(EAX_VENDOR_INFO) };
+
+    let eax = result.eax;
+
+    let model = (eax >> 4) & 0xf;
+    let family = (eax >> 8) & 0xf;
+    let extended_model = (eax >> 16) & 0xf;
+    let extended_family = (eax >> 20) & 0xff;
+
+    if family == 0xf && extended_family == 0x8 {
+        // AMD Family 23 (17h)
+        if extended_model == 0x0 || extended_model == 0x1 || extended_model == 0x2 {
+            return AMDZEN1;
+        } else if extended_model == 0x3
+            || extended_model == 0x4
+            || extended_model == 0x6
+            || extended_model == 0x7
+            || extended_model == 0x9
+        {
+            return AMDZEN2;
+        }
+    } else if family == 0xf && extended_family == 0xa {
+        // AMD Family 25 (19h)
+        if extended_model == 0x0
+            || extended_model == 0x2
+            || extended_model == 0x4
+            || extended_model == 0x5
+        {
+            return AMDZEN3;
+        } else if extended_model == 0x1 || extended_model == 0x6 || extended_model == 0x7 {
+            return AMDZEN4;
+        }
+    } else if family == 0x6 && extended_family == 0 {
+        // Recent Intel processors
+        if (extended_model == 0x3 && model == 0xc)
+            || (extended_model == 0x4 && (model == 0x5 || model == 0x6))
+        {
+            return INTEL_HASWELL;
+        } else if (extended_model == 0x3 && model == 0xd) || (extended_model == 0x4 && model == 0x7)
+        {
+            return INTEL_BROADWELL;
+        } else if (extended_model == 0x5 && model == 0xe) || (extended_model == 0x4 && model == 0xe)
+        {
+            return INTEL_SKYLAKE;
+        } else if (extended_model == 0x8 && model == 0xe) || (extended_model == 0x9 && model == 0xe)
+        {
+            return INTEL_KABYLAKE;
+        } else if extended_model == 0xa && model == 0x5 {
+            return INTEL_COMETLAKE;
+        } else if extended_model == 0x7 && model == 0xe {
+            return INTEL_ICELAKE;
+        } else if extended_model == 0x6 && (model == 0xc || model == 0xa) {
+            return INTEL_ICX;
+        } else if extended_model == 0x8 && (model == 0xc || model == 0xd) {
+            return INTEL_TIGERLAKE;
+        } else if extended_model == 0xa && model == 0x7 {
+            return INTEL_ROCKETLAKE;
+        } else if extended_model == 0x9 && (model == 0x7 || model == 0xa) {
+            return INTEL_ALDERLAKE;
+        } else if extended_model == 0xb && (model == 0x7 || model == 0xa) {
+            return INTEL_RAPTORLAKE;
+        }
+    }
+
+    "unknown"
+}

--- a/pmu/src/cpu_family.rs
+++ b/pmu/src/cpu_family.rs
@@ -1,11 +1,7 @@
 use std::collections::HashMap;
 
 use lazy_static::lazy_static;
-use pmu_data::{
-    EventDesc, AMDZEN1, AMDZEN2, AMDZEN3, AMDZEN4, INTEL_ALDERLAKE, INTEL_BROADWELL,
-    INTEL_COMETLAKE, INTEL_HASWELL, INTEL_ICELAKE, INTEL_ICX, INTEL_KABYLAKE, INTEL_RAPTORLAKE,
-    INTEL_ROCKETLAKE, INTEL_SKYLAKE, INTEL_TIGERLAKE,
-};
+use pmu_data::EventDesc;
 
 pub struct CPUFamily {
     pub name: String,
@@ -37,14 +33,14 @@ pub fn get_host_cpu_family() -> &'static str {
     if family == 0xf && extended_family == 0x8 {
         // AMD Family 23 (17h)
         if extended_model == 0x0 || extended_model == 0x1 || extended_model == 0x2 {
-            return AMDZEN1;
+            return pmu_data::AMDZEN1;
         } else if extended_model == 0x3
             || extended_model == 0x4
             || extended_model == 0x6
             || extended_model == 0x7
             || extended_model == 0x9
         {
-            return AMDZEN2;
+            return pmu_data::AMDZEN2;
         }
     } else if family == 0xf && extended_family == 0xa {
         // AMD Family 25 (19h)
@@ -53,41 +49,61 @@ pub fn get_host_cpu_family() -> &'static str {
             || extended_model == 0x4
             || extended_model == 0x5
         {
-            return AMDZEN3;
+            return pmu_data::AMDZEN3;
         } else if extended_model == 0x1 || extended_model == 0x6 || extended_model == 0x7 {
-            return AMDZEN4;
+            return pmu_data::AMDZEN4;
         }
     } else if family == 0x6 && extended_family == 0 {
         // Recent Intel processors
         if (extended_model == 0x3 && model == 0xc)
             || (extended_model == 0x4 && (model == 0x5 || model == 0x6))
         {
-            return INTEL_HASWELL;
+            return pmu_data::INTEL_HASWELL;
         } else if (extended_model == 0x3 && model == 0xd) || (extended_model == 0x4 && model == 0x7)
         {
-            return INTEL_BROADWELL;
+            return pmu_data::INTEL_BROADWELL;
         } else if (extended_model == 0x5 && model == 0xe) || (extended_model == 0x4 && model == 0xe)
         {
-            return INTEL_SKYLAKE;
+            return pmu_data::INTEL_SKYLAKE;
         } else if (extended_model == 0x8 && model == 0xe) || (extended_model == 0x9 && model == 0xe)
         {
-            return INTEL_KABYLAKE;
+            return pmu_data::INTEL_KABYLAKE;
         } else if extended_model == 0xa && model == 0x5 {
-            return INTEL_COMETLAKE;
+            return pmu_data::INTEL_COMETLAKE;
         } else if extended_model == 0x7 && model == 0xe {
-            return INTEL_ICELAKE;
+            return pmu_data::INTEL_ICELAKE;
         } else if extended_model == 0x6 && (model == 0xc || model == 0xa) {
-            return INTEL_ICX;
+            return pmu_data::INTEL_ICX;
         } else if extended_model == 0x8 && (model == 0xc || model == 0xd) {
-            return INTEL_TIGERLAKE;
+            return pmu_data::INTEL_TIGERLAKE;
         } else if extended_model == 0xa && model == 0x7 {
-            return INTEL_ROCKETLAKE;
+            return pmu_data::INTEL_ROCKETLAKE;
         } else if extended_model == 0x9 && (model == 0x7 || model == 0xa) {
-            return INTEL_ALDERLAKE;
+            return pmu_data::INTEL_ALDERLAKE;
         } else if extended_model == 0xb && (model == 0x7 || model == 0xa) {
-            return INTEL_RAPTORLAKE;
+            return pmu_data::INTEL_RAPTORLAKE;
         }
     }
 
     "unknown"
+}
+
+#[cfg(target_arch = "riscv64")]
+fn get_cpu_family() -> ProcessorFamily {
+    use proc_getter::cpuinfo::cpuinfo;
+
+    let info = cpuinfo().expect("/proc/cpuinfo is inaccessible");
+    let marchid = info[0].get("marchid");
+
+    match marchid {
+        Some(marchid) => {
+            if marchid == "0x8000000000000007" {
+                // TODO(Alex): technically speaking this also includes E7 and S7
+                pmu_data::SIFIVE_U7
+            } else {
+                "unknown"
+            }
+        }
+        None => "unknown",
+    }
 }

--- a/pmu/src/cpu_family.rs
+++ b/pmu/src/cpu_family.rs
@@ -89,7 +89,7 @@ pub fn get_host_cpu_family() -> &'static str {
 }
 
 #[cfg(target_arch = "riscv64")]
-fn get_host_cpu_family() -> ProcessorFamily {
+pub fn get_host_cpu_family() -> ProcessorFamily {
     use proc_getter::cpuinfo::cpuinfo;
 
     let info = cpuinfo().expect("/proc/cpuinfo is inaccessible");

--- a/pmu/src/cpu_family.rs
+++ b/pmu/src/cpu_family.rs
@@ -89,7 +89,7 @@ pub fn get_host_cpu_family() -> &'static str {
 }
 
 #[cfg(target_arch = "riscv64")]
-pub fn get_host_cpu_family() -> ProcessorFamily {
+pub fn get_host_cpu_family() -> &'static str {
     use proc_getter::cpuinfo::cpuinfo;
 
     let info = cpuinfo().expect("/proc/cpuinfo is inaccessible");

--- a/pmu/src/driver/mod.rs
+++ b/pmu/src/driver/mod.rs
@@ -5,7 +5,7 @@ mod perf;
 mod kperf;
 
 #[cfg(target_os = "linux")]
-pub use perf::{list_software_counters, CountingDriver, SamplingDriver};
+pub use perf::{list_supported_counters, CountingDriver, SamplingDriver};
 
 #[cfg(target_os = "macos")]
 pub use kperf::{list_software_counters, Driver};

--- a/pmu/src/driver/perf.rs
+++ b/pmu/src/driver/perf.rs
@@ -113,10 +113,6 @@ struct EventValue {
     id: u64,
 }
 
-pub fn list_software_counters() -> Vec<Counter> {
-    vec![]
-}
-
 impl CountingDriver {
     pub fn new(counters: &[Counter], process: Option<&Process>) -> Result<Self, Error> {
         let mut attrs = get_native_counters(counters, false)?;

--- a/pmu/src/driver/perf.rs
+++ b/pmu/src/driver/perf.rs
@@ -1,8 +1,11 @@
+mod events;
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
+use events::process_counter;
 use libc::{close, mmap, munmap, sysconf, MAP_FAILED, MAP_SHARED, PROT_READ, PROT_WRITE};
 use perf_event_open_sys::bindings::{
     perf_event_attr, perf_event_header, perf_event_mmap_page, PERF_RECORD_SAMPLE, PERF_SAMPLE_CPU,
@@ -11,6 +14,8 @@ use perf_event_open_sys::bindings::{
 use perf_event_open_sys::{self as sys, bindings::PERF_SAMPLE_IDENTIFIER};
 
 use crate::{Counter, Error, Process};
+
+pub use events::list_supported_counters;
 
 /// Counting driver is used for simple collection of system's performance counters values. On Linux,
 /// counter multiplexing is supported.
@@ -32,6 +37,7 @@ pub struct SamplingDriverBuilder {
     counters: Vec<Counter>,
     sample_freq: u64,
     pid: Option<i32>,
+    prefer_raw_events: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -113,7 +119,7 @@ pub fn list_software_counters() -> Vec<Counter> {
 
 impl CountingDriver {
     pub fn new(counters: &[Counter], process: Option<&Process>) -> Result<Self, Error> {
-        let mut attrs = get_native_counters(counters)?;
+        let mut attrs = get_native_counters(counters, false)?;
 
         for attr in &mut attrs {
             attr.set_exclude_kernel(1);
@@ -128,7 +134,7 @@ impl CountingDriver {
 
         let pid = process.map(|p| p.pid());
 
-        let native_handles = bind_events(counters, &mut attrs, pid)?;
+        let native_handles = bind_counters(counters, &mut attrs, pid)?;
 
         Ok(CountingDriver { native_handles })
     }
@@ -239,6 +245,7 @@ impl SamplingDriver {
             counters: vec![],
             sample_freq: 1000,
             pid: None,
+            prefer_raw_events: false,
         }
     }
 
@@ -375,6 +382,7 @@ impl SamplingDriverBuilder {
             counters: counters.to_vec(),
             sample_freq: self.sample_freq,
             pid: self.pid,
+            prefer_raw_events: self.prefer_raw_events,
         }
     }
 
@@ -383,6 +391,7 @@ impl SamplingDriverBuilder {
             counters: self.counters,
             sample_freq: self.sample_freq,
             pid: Some(process.pid()),
+            prefer_raw_events: self.prefer_raw_events,
         }
     }
 
@@ -391,11 +400,12 @@ impl SamplingDriverBuilder {
             counters: self.counters,
             sample_freq,
             pid: self.pid,
+            prefer_raw_events: self.prefer_raw_events,
         }
     }
 
     pub fn build(self) -> Result<SamplingDriver, Error> {
-        let mut attrs = get_native_counters(&self.counters)?;
+        let mut attrs = get_native_counters(&self.counters, self.prefer_raw_events)?;
 
         for attr in &mut attrs {
             attr.set_exclude_kernel(1);
@@ -415,7 +425,7 @@ impl SamplingDriverBuilder {
             attr.set_mmap(1);
         }
 
-        let native_handles = bind_events(&self.counters, &mut attrs, self.pid)?;
+        let native_handles = bind_counters(&self.counters, &mut attrs, self.pid)?;
 
         let page_size = unsafe { sysconf(libc::_SC_PAGE_SIZE) } as usize;
         let mmap_pages = 512;
@@ -490,7 +500,10 @@ impl IntoIterator for CounterResult {
     }
 }
 
-fn get_native_counters(counters: &[Counter]) -> Result<Vec<perf_event_attr>, Error> {
+fn get_native_counters(
+    counters: &[Counter],
+    prefer_raw_counters: bool,
+) -> Result<Vec<perf_event_attr>, Error> {
     let attrs = counters
         .iter()
         .map(|cntr| {
@@ -503,6 +516,8 @@ fn get_native_counters(counters: &[Counter]) -> Result<Vec<perf_event_attr>, Err
                 | sys::bindings::PERF_FORMAT_ID as u64
                 | sys::bindings::PERF_FORMAT_TOTAL_TIME_ENABLED as u64
                 | sys::bindings::PERF_FORMAT_TOTAL_TIME_RUNNING as u64;
+
+            let cntr = process_counter(cntr, prefer_raw_counters);
 
             match cntr {
                 Counter::Cycles => {
@@ -537,6 +552,30 @@ fn get_native_counters(counters: &[Counter]) -> Result<Vec<perf_event_attr>, Err
                     attrs.type_ = sys::bindings::PERF_TYPE_HARDWARE;
                     attrs.config = sys::bindings::PERF_COUNT_HW_STALLED_CYCLES_BACKEND as u64;
                 }
+                Counter::CpuClock => {
+                    attrs.type_ = sys::bindings::PERF_TYPE_SOFTWARE;
+                    attrs.config = sys::bindings::PERF_COUNT_SW_CPU_CLOCK as u64;
+                }
+                Counter::ContextSwitches => {
+                    attrs.type_ = sys::bindings::PERF_TYPE_SOFTWARE;
+                    attrs.config = sys::bindings::PERF_COUNT_SW_CONTEXT_SWITCHES as u64;
+                }
+                Counter::CpuMigrations => {
+                    attrs.type_ = sys::bindings::PERF_TYPE_SOFTWARE;
+                    attrs.config = sys::bindings::PERF_COUNT_SW_CPU_MIGRATIONS as u64;
+                }
+                Counter::PageFaults => {
+                    attrs.type_ = sys::bindings::PERF_TYPE_SOFTWARE;
+                    attrs.config = sys::bindings::PERF_COUNT_SW_PAGE_FAULTS as u64;
+                }
+                Counter::Internal {
+                    name: _,
+                    desc: _,
+                    code,
+                } => {
+                    attrs.type_ = sys::bindings::PERF_TYPE_RAW;
+                    attrs.config = code;
+                }
                 _ => todo!(),
             }
 
@@ -547,7 +586,7 @@ fn get_native_counters(counters: &[Counter]) -> Result<Vec<perf_event_attr>, Err
     Ok(attrs)
 }
 
-fn bind_events(
+fn bind_counters(
     counters: &[Counter],
     attrs: &mut [perf_event_attr],
     pid: Option<i32>,

--- a/pmu/src/driver/perf.rs
+++ b/pmu/src/driver/perf.rs
@@ -404,6 +404,15 @@ impl SamplingDriverBuilder {
         }
     }
 
+    pub fn prefer_raw_events(self) -> Self {
+        Self {
+            counters: self.counters,
+            sample_freq: self.sample_freq,
+            pid: self.pid,
+            prefer_raw_events: true,
+        }
+    }
+
     pub fn build(self) -> Result<SamplingDriver, Error> {
         let mut attrs = get_native_counters(&self.counters, self.prefer_raw_events)?;
 

--- a/pmu/src/driver/perf/events.rs
+++ b/pmu/src/driver/perf/events.rs
@@ -1,0 +1,104 @@
+use crate::{cpu_family, Counter};
+
+pub fn list_supported_counters() -> Vec<Counter> {
+    let mut counters = vec![
+        Counter::Cycles,
+        Counter::Instructions,
+        Counter::BranchInstructions,
+        Counter::BranchMisses,
+        Counter::LLCMisses,
+        Counter::LLCReferences,
+        Counter::StalledCyclesFrontend,
+        Counter::StalledCyclesBackend,
+        Counter::CpuClock,
+        Counter::PageFaults,
+        Counter::CpuMigrations,
+        Counter::ContextSwitches,
+    ];
+
+    let cpu_family = cpu_family::get_host_cpu_family();
+    let events = cpu_family::find_cpu_family(cpu_family);
+
+    if let Some(events) = events {
+        for evt in events.events.values() {
+            counters.push(Counter::Internal {
+                name: evt.name.clone(),
+                desc: evt.desc.clone(),
+                code: evt.code,
+            });
+        }
+    }
+
+    counters
+}
+
+pub fn process_counter(counter: &Counter, prefer_raw_counters: bool) -> Counter {
+    if let Counter::Custom(name) = counter {
+        let cpu_family = cpu_family::get_host_cpu_family();
+        let info = cpu_family::find_cpu_family(cpu_family);
+        if info.is_none() {
+            panic!("Unsupported CPU family '{}'", cpu_family);
+        }
+
+        let info = info.unwrap();
+
+        let counter = info.events.get(name);
+
+        if counter.is_none() {
+            panic!(
+                "Unsupported counter '{}' for CPU family '{}'",
+                name, cpu_family
+            );
+        }
+
+        let counter = counter.unwrap();
+
+        return Counter::Internal {
+            name: counter.name.clone(),
+            desc: counter.desc.clone(),
+            code: counter.code,
+        };
+    } else if prefer_raw_counters {
+        let cpu_family = cpu_family::get_host_cpu_family();
+        let info = cpu_family::find_cpu_family(cpu_family);
+        if info.is_none() {
+            return counter.clone();
+        }
+
+        let info = info.unwrap();
+
+        let alias_name = match counter {
+            Counter::Cycles => "cycles",
+            Counter::Instructions => "instructions",
+            Counter::LLCMisses => "cache_misses",
+            Counter::LLCReferences => "cache_references",
+            Counter::BranchMisses => "branch_misses",
+            Counter::BranchInstructions => "branches",
+            Counter::StalledCyclesBackend => "stalled_cycles_backend",
+            Counter::StalledCyclesFrontend => "stalled_cycles_frontend",
+            _ => return counter.clone(),
+        };
+
+        let alias = info.aliases.get(alias_name);
+
+        if alias.is_none() {
+            return counter.clone();
+        }
+
+        let new_counter = info.events.get(alias.unwrap());
+
+        if new_counter.is_none() {
+            return counter.clone();
+        }
+
+        let new_counter = new_counter.unwrap();
+
+        return Counter::Internal {
+            name: new_counter.name.clone(),
+            desc: new_counter.desc.clone(),
+            code: new_counter.code,
+        };
+    }
+
+    counter.clone()
+}

--- a/pmu/src/lib.rs
+++ b/pmu/src/lib.rs
@@ -2,7 +2,7 @@ mod cpu_family;
 mod driver;
 mod process;
 
-pub use driver::{CountingDriver, SamplingDriver, list_supported_counters};
+pub use driver::{list_supported_counters, CountingDriver, SamplingDriver};
 pub use process::Process;
 
 use thiserror::Error;
@@ -22,7 +22,11 @@ pub enum Counter {
     ContextSwitches,
     CpuMigrations,
     Custom(String),
-    Internal{name: String, desc: String, code: u64},
+    Internal {
+        name: String,
+        desc: String,
+        code: u64,
+    },
 }
 
 #[derive(Error, Debug)]
@@ -49,7 +53,11 @@ impl Counter {
             Counter::ContextSwitches => "context_switches",
             Counter::CpuMigrations => "cpu_migrations",
             Counter::Custom(name) => name,
-            Counter::Internal{name, desc: _, code: _} => name,
+            Counter::Internal {
+                name,
+                desc: _,
+                code: _,
+            } => name,
         }
     }
 
@@ -70,7 +78,11 @@ impl Counter {
             Counter::ContextSwitches => "Number of context switches",
             Counter::CpuMigrations => "Number of the times the process has migrated to a new CPU",
             Counter::Custom(_) => "",
-            Counter::Internal{name: _, desc, code: _} => desc,
+            Counter::Internal {
+                name: _,
+                desc,
+                code: _,
+            } => desc,
         }
     }
 }

--- a/pmu/src/lib.rs
+++ b/pmu/src/lib.rs
@@ -1,7 +1,8 @@
+mod cpu_family;
 mod driver;
 mod process;
 
-pub use driver::{CountingDriver, SamplingDriver};
+pub use driver::{CountingDriver, SamplingDriver, list_supported_counters};
 pub use process::Process;
 
 use thiserror::Error;
@@ -16,7 +17,12 @@ pub enum Counter {
     BranchMisses,
     StalledCyclesFrontend,
     StalledCyclesBackend,
+    CpuClock,
+    PageFaults,
+    ContextSwitches,
+    CpuMigrations,
     Custom(String),
+    Internal{name: String, desc: String, code: u64},
 }
 
 #[derive(Error, Debug)]
@@ -25,21 +31,6 @@ pub enum Error {
     CounterCreationFail,
     #[error("Failed to enable counters")]
     EnableFailed,
-}
-
-pub fn list_counters() -> Vec<Counter> {
-    let mut counters = vec![
-        Counter::Cycles,
-        Counter::Instructions,
-        Counter::LLCReferences,
-        Counter::LLCMisses,
-        Counter::BranchInstructions,
-        Counter::BranchMisses,
-    ];
-
-    counters.extend(driver::list_software_counters());
-
-    counters
 }
 
 impl Counter {
@@ -53,7 +44,12 @@ impl Counter {
             Counter::BranchMisses => "branch_misses",
             Counter::StalledCyclesFrontend => "stalled_cycles_frontend",
             Counter::StalledCyclesBackend => "stalled_cycles_backend",
-            _ => todo!(),
+            Counter::CpuClock => "cpu_clock",
+            Counter::PageFaults => "page_faults",
+            Counter::ContextSwitches => "context_switches",
+            Counter::CpuMigrations => "cpu_migrations",
+            Counter::Custom(name) => name,
+            Counter::Internal{name, desc: _, code: _} => name,
         }
     }
 
@@ -69,7 +65,12 @@ impl Counter {
                 "Number of cycles stalled due to frontend bottlenecks"
             }
             Counter::StalledCyclesBackend => "Number of cycles stalled due to backend bottlenecks",
-            _ => todo!(),
+            Counter::CpuClock => "A high-resolution per-CPU timer",
+            Counter::PageFaults => "Number of page faults",
+            Counter::ContextSwitches => "Number of context switches",
+            Counter::CpuMigrations => "Number of the times the process has migrated to a new CPU",
+            Counter::Custom(_) => "",
+            Counter::Internal{name: _, desc, code: _} => desc,
         }
     }
 }


### PR DESCRIPTION
By default perf_event_open only gives access to a set of "generalized" events, which is not enough to fully utilize available PMU counters. This patch adds support for JSON format and raw perf events so that in future mperf is able to provide full TMA support.