### PR TITLE
fix: use groups in sampling mode

### DIFF
--- a/pmu-data/src/lib.rs
+++ b/pmu-data/src/lib.rs
@@ -27,6 +27,7 @@ pub struct PlatformDesc {
     pub name: String,
     pub vendor: String,
     pub arch: String,
+    pub max_counters: Option<usize>,
     pub events: Vec<EventDesc>,
     pub aliases: Option<Vec<Alias>>,
 }

--- a/pmu/Cargo.toml
+++ b/pmu/Cargo.toml
@@ -10,6 +10,7 @@ thiserror = "2.0.9"
 pmu-data = { path = "../pmu-data/" }
 lazy_static = "1.5.0"
 smallvec = "1.13.2"
+itertools = "0.14.0"
 
 [target.'cfg(unix)'.dependencies]
 proc_getter = "0.0.3"

--- a/pmu/build.rs
+++ b/pmu/build.rs
@@ -52,6 +52,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         let name = &data.name;
         let vendor = &data.vendor;
         let family_id = &data.family_id;
+        let max_counters = data
+            .max_counters
+            .map(|num| quote! {Some(#num)})
+            .unwrap_or(quote! { None });
 
         families.push(quote! {
             let mut events = HashMap::new();
@@ -66,6 +70,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 name: #name.to_string(),
                 vendor: #vendor.to_string(),
                 id: #family_id.to_string(),
+                max_counters: #max_counters,
                 events,
                 aliases,
             };

--- a/pmu/src/cpu_family.rs
+++ b/pmu/src/cpu_family.rs
@@ -8,6 +8,7 @@ pub struct CPUFamily {
     pub name: String,
     pub vendor: String,
     pub id: String,
+    pub max_counters: Option<usize>,
     pub events: HashMap<String, EventDesc>,
     pub aliases: HashMap<String, String>,
 }

--- a/pmu/src/driver/perf.rs
+++ b/pmu/src/driver/perf.rs
@@ -1,3 +1,4 @@
+mod binding;
 mod events;
 
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -78,6 +79,7 @@ struct NativeCounterHandle {
     pub kind: Counter,
     pub id: u64,
     pub fd: i32,
+    pub leader: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -133,20 +135,14 @@ impl CountingDriver {
 
         let pid = process.map(|p| p.pid());
 
-        let native_handles = bind_counters(counters, &mut attrs, pid)?;
+        let native_handles = binding::direct(counters, &mut attrs, pid)?;
 
         Ok(CountingDriver { native_handles })
     }
 
     pub fn start(&mut self) -> Result<(), Error> {
         for handle in &self.native_handles {
-            let res_enable = unsafe {
-                sys::ioctls::ENABLE(
-                    handle.fd,
-                    0, // TODO support groups
-                      // sys::bindings::PERF_IOC_FLAG_GROUP,
-                )
-            };
+            let res_enable = unsafe { sys::ioctls::ENABLE(handle.fd, 0) };
 
             if res_enable < 0 {
                 return Err(Error::EnableFailed);
@@ -242,7 +238,7 @@ impl SamplingDriver {
     pub fn builder() -> SamplingDriverBuilder {
         SamplingDriverBuilder {
             counters: vec![],
-            sample_freq: 1000,
+            sample_freq: 4000,
             pid: None,
             prefer_raw_events: false,
         }
@@ -253,13 +249,12 @@ impl SamplingDriver {
         F: FnMut(Sample) + Send + 'static,
     {
         for handle in &self.native_handles {
-            let res_enable = unsafe {
-                sys::ioctls::ENABLE(
-                    handle.fd,
-                    0, // TODO support groups
-                      // sys::bindings::PERF_IOC_FLAG_GROUP,
-                )
-            };
+            if !handle.leader {
+                continue;
+            }
+
+            let res_enable =
+                unsafe { sys::ioctls::ENABLE(handle.fd, sys::bindings::PERF_IOC_FLAG_GROUP) };
 
             if res_enable < 0 {
                 return Err(Error::EnableFailed);
@@ -326,27 +321,31 @@ impl SamplingDriver {
                                 let (_next_ptr, callstack) =
                                     SampleFormat::read_callchain(current_ptr);
 
-                                let value = &values[0];
+                                for value in values {
+                                    let handle = native_handles
+                                        .iter()
+                                        .find(|handle| handle.id == value.id)
+                                        .unwrap();
 
-                                let handle = native_handles
-                                    .iter()
-                                    .find(|handle| handle.id == value.id)
-                                    .unwrap();
+                                    let sample = Sample {
+                                        event_id: format.id,
+                                        ip: format.ip,
+                                        pid: format.pid,
+                                        tid: format.tid,
+                                        time: format.time,
+                                        time_enabled: format.read.time_enabled,
+                                        time_running: format.read.time_running,
+                                        counter: handle.kind.clone(),
+                                        value: value.value,
+                                        callstack: callstack[1..].to_smallvec(),
+                                    };
 
-                                let sample = Sample {
-                                    event_id: format.id,
-                                    ip: format.ip,
-                                    pid: format.pid,
-                                    tid: format.tid,
-                                    time: format.time,
-                                    time_enabled: format.read.time_enabled,
-                                    time_running: format.read.time_running,
-                                    counter: handle.kind.clone(),
-                                    value: value.value,
-                                    callstack: callstack[1..].to_smallvec(),
-                                };
+                                    callback(sample);
+                                }
+                            }
 
-                                callback(sample);
+                            if !running.load(Ordering::SeqCst) {
+                                break;
                             }
 
                             offset += header.size as usize;
@@ -368,13 +367,12 @@ impl SamplingDriver {
         self.running.store(false, Ordering::SeqCst);
 
         for handle in &self.native_handles {
-            let res_enable = unsafe {
-                sys::ioctls::DISABLE(
-                    handle.fd,
-                    0, // TODO support groups
-                      // sys::bindings::PERF_IOC_FLAG_GROUP,
-                )
-            };
+            if !handle.leader {
+                continue;
+            }
+
+            let res_enable =
+                unsafe { sys::ioctls::DISABLE(handle.fd, sys::bindings::PERF_IOC_FLAG_GROUP) };
 
             if res_enable < 0 {
                 return Err(Error::EnableFailed);
@@ -443,7 +441,7 @@ impl SamplingDriverBuilder {
             attr.set_mmap(1);
         }
 
-        let native_handles = bind_counters(&self.counters, &mut attrs, self.pid)?;
+        let native_handles = binding::grouped(&self.counters, &mut attrs, self.pid)?;
 
         let page_size = unsafe { sysconf(libc::_SC_PAGE_SIZE) } as usize;
         let mmap_pages = 512;
@@ -602,50 +600,6 @@ fn get_native_counters(
         .collect::<Vec<_>>();
 
     Ok(attrs)
-}
-
-fn bind_counters(
-    counters: &[Counter],
-    attrs: &mut [perf_event_attr],
-    pid: Option<i32>,
-) -> Result<Vec<NativeCounterHandle>, Error> {
-    let mut handles: Vec<NativeCounterHandle> = vec![];
-
-    for (cntr, attr) in std::iter::zip(counters, attrs) {
-        // cycles and instructions are typically fixed counters and thus always on
-        match cntr {
-            Counter::Cycles | Counter::Instructions => attr.set_pinned(1),
-            _ => attr.set_pinned(0),
-        };
-        let new_fd = unsafe {
-            sys::perf_event_open(
-                &mut *attr as *mut perf_event_attr,
-                pid.unwrap_or(0),
-                -1,
-                -1,
-                0,
-            )
-        };
-
-        if new_fd < 0 {
-            return Err(Error::CounterCreationFail);
-        }
-
-        let mut id: u64 = 0;
-
-        let result = unsafe { sys::ioctls::ID(new_fd, &mut id) };
-        if result < 0 {
-            return Err(Error::CounterCreationFail);
-        }
-
-        handles.push(NativeCounterHandle {
-            kind: cntr.clone(),
-            id,
-            fd: new_fd,
-        });
-    }
-
-    Ok(handles)
 }
 
 impl SampleFormat {

--- a/pmu/src/driver/perf/binding.rs
+++ b/pmu/src/driver/perf/binding.rs
@@ -1,0 +1,121 @@
+use std::iter::zip;
+
+use itertools::Itertools;
+use perf_event_open_sys::{self as sys, bindings::perf_event_attr};
+
+use crate::{cpu_family, Counter, Error};
+
+use super::NativeCounterHandle;
+
+pub fn direct(
+    counters: &[Counter],
+    attrs: &mut [perf_event_attr],
+    pid: Option<i32>,
+) -> Result<Vec<NativeCounterHandle>, Error> {
+    let mut handles: Vec<NativeCounterHandle> = vec![];
+
+    for (cntr, attr) in std::iter::zip(counters, attrs) {
+        // cycles and instructions are typically fixed counters and thus always on
+        match cntr {
+            Counter::Cycles | Counter::Instructions => attr.set_pinned(1),
+            _ => attr.set_pinned(0),
+        };
+        let new_fd = unsafe {
+            sys::perf_event_open(
+                &mut *attr as *mut perf_event_attr,
+                pid.unwrap_or(0),
+                -1,
+                -1,
+                0,
+            )
+        };
+
+        if new_fd < 0 {
+            return Err(Error::CounterCreationFail);
+        }
+
+        let mut id: u64 = 0;
+
+        let result = unsafe { sys::ioctls::ID(new_fd, &mut id) };
+        if result < 0 {
+            return Err(Error::CounterCreationFail);
+        }
+
+        handles.push(NativeCounterHandle {
+            kind: cntr.clone(),
+            id,
+            fd: new_fd,
+            leader: false,
+        });
+    }
+
+    Ok(handles)
+}
+
+pub fn grouped(
+    counters: &[Counter],
+    attrs: &mut [perf_event_attr],
+    pid: Option<i32>,
+) -> Result<Vec<NativeCounterHandle>, Error> {
+    let cpu_family = cpu_family::get_host_cpu_family();
+    let info = cpu_family::find_cpu_family(cpu_family);
+
+    let max_counters_in_group = info.and_then(|info| info.max_counters).unwrap_or(3);
+
+    let mut cycles_attrs = zip(counters, attrs.iter())
+        .find(|(cntr, _)| **cntr == Counter::Cycles)
+        .map(|(_, attrs)| attrs)
+        .cloned()
+        .expect("Cycles are required for correct sampling");
+    let mut instr_attrs = zip(counters, attrs.iter())
+        .find(|(cntr, _)| **cntr == Counter::Instructions)
+        .map(|(_, attrs)| attrs)
+        .cloned()
+        .expect("Instructions are required for correct sampling");
+
+    let chunks = zip(counters, attrs.iter_mut())
+        .filter(|(cntr, _)| **cntr != Counter::Cycles && **cntr != Counter::Instructions)
+        .chunks(max_counters_in_group);
+
+    let mut handles: Vec<NativeCounterHandle> = vec![];
+
+    for chunk in chunks.into_iter() {
+        let cycles_fd =
+            unsafe { sys::perf_event_open(&mut cycles_attrs, pid.unwrap_or(0), -1, -1, 0) };
+
+        handles.push(get_native_handle(cycles_fd, Counter::Cycles, true)?);
+
+        let instr_fd =
+            unsafe { sys::perf_event_open(&mut instr_attrs, pid.unwrap_or(0), -1, cycles_fd, 0) };
+
+        handles.push(get_native_handle(instr_fd, Counter::Instructions, false)?);
+
+        for (cntr, attrs) in chunk {
+            let new_fd =
+                unsafe { sys::perf_event_open(&mut *attrs, pid.unwrap_or(0), -1, cycles_fd, 0) };
+            handles.push(get_native_handle(new_fd, cntr.clone(), false)?);
+        }
+    }
+
+    Ok(handles)
+}
+
+fn get_native_handle(fd: i32, cntr: Counter, leader: bool) -> Result<NativeCounterHandle, Error> {
+    if fd < 0 {
+        return Err(Error::CounterCreationFail);
+    }
+
+    let mut id: u64 = 0;
+
+    let result = unsafe { sys::ioctls::ID(fd, &mut id) };
+    if result < 0 {
+        return Err(Error::CounterCreationFail);
+    }
+
+    Ok(NativeCounterHandle {
+        kind: cntr,
+        id,
+        fd,
+        leader,
+    })
+}


### PR DESCRIPTION
Instead of running each counter individually at different frequency, split counters in groups and make them count on cycles overflow.