### PR TITLE
fix: properly monitor process maps

### DIFF
--- a/mperf-data/src/event.rs
+++ b/mperf-data/src/event.rs
@@ -1,4 +1,4 @@
-use std::io::{BufRead, Write};
+use std::{collections::HashSet, io::{BufRead, Write}};
 
 use capnp::message::ReaderOptions;
 use serde::{Deserialize, Serialize};
@@ -71,7 +71,7 @@ pub struct Event {
     pub callstack: SmallVec<[CallFrame; 32]>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
 pub struct ProcMapEntry {
     pub filename: String,
     pub address: usize,
@@ -145,10 +145,10 @@ impl EventType {
 }
 
 impl ProcMap {
-    pub fn new(map: (u32, Vec<ProcMapEntry>)) -> Self {
+    pub fn new(map: (u32, HashSet<ProcMapEntry>)) -> Self {
         Self {
             pid: map.0,
-            entries: map.1,
+            entries: map.1.into_iter().collect(),
         }
     }
 }

--- a/mperf/src/event_dispatcher.rs
+++ b/mperf/src/event_dispatcher.rs
@@ -2,7 +2,7 @@
 
 use std::cell::RefCell;
 use std::collections::HashSet;
-use std::{collections::HashMap, path::Path, sync::Arc};
+use std::{collections::HashMap, path::Path, sync::Arc, iter::Extend};
 
 use mperf_data::{Event, IString, ProcMap, ProcMapEntry};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
@@ -63,25 +63,31 @@ impl EventDispatcher {
 
         let proc_map_out_dir = output_directory.to_owned();
         let proc_map_worker = tokio::spawn(async move {
-            let mut proc_map_entries = HashMap::<u32, Vec<ProcMapEntry>>::new();
+            // let mut proc_map_entries = Hash::<u32, Vec<ProcMapEntry>>::new();
+            let mut proc_map_entries = HashMap::<u32, HashSet::<ProcMapEntry>>::new();
             while let Some(pid) = proc_map_rx.recv().await {
                 if let Ok(maps) = get_process_maps(pid as Pid) {
                     let pm = maps
                         .iter()
-                        .map(|m| ProcMapEntry {
-                            filename: m
-                                .filename()
-                                .map(|p| p.to_str().unwrap_or("unknown").to_owned())
-                                .unwrap_or("unknown".to_string()),
-                            address: m.start(),
-                            size: m.size(),
-                        })
-                        .collect::<Vec<ProcMapEntry>>();
-                    if !proc_map_entries.contains_key(&pid)
-                        || proc_map_entries.get(&pid).unwrap().len() < pm.len()
-                    {
-                        proc_map_entries.insert(pid, pm);
-                    }
+                        .filter_map(|m| {
+                            if m.filename().is_none() || m.filename().unwrap().ends_with("mperf") {
+                                return None;
+                            }
+                            Some(ProcMapEntry {
+                                filename: m
+                                    .filename()
+                                    .map(|p| p.to_str().unwrap_or("unknown").to_owned())
+                                    .unwrap_or("unknown".to_string()),
+                                address: m.start(),
+                                size: m.size(),
+                            })
+                        });
+
+                    proc_map_entries.entry(pid).or_default();
+
+                    let set = proc_map_entries.get_mut(&pid).unwrap();
+
+                    set.extend(pm.into_iter());
                 }
             }
 


### PR DESCRIPTION
At the very beginning mperf does a fork of a process to then execute a child via execve call after profiler is set up. During this small period some events get caught by mperf that are attributed to itself. This heavily messes up the profiling results. Instead, make sure mperf is ignored by process map monitor and the maps are appended instead of just replaced. Still need to find a way to throttle these events.